### PR TITLE
Add node pausing functionality

### DIFF
--- a/src/features/scene-switching/scene_switching.gd
+++ b/src/features/scene-switching/scene_switching.gd
@@ -1,0 +1,25 @@
+extends Node
+## Global singleton script to orchastrate scene switching
+
+## currently active scene
+var current_scene:Node = null
+
+## Sets current scene
+func _ready() -> void:
+	var root:Window = get_tree().root
+	current_scene = root.get_child(root.get_child_count() - 1)
+
+## Changes scene to main menu
+func goto_mainmenu() -> void:
+	goto_scene("res://scenes/guis/MainMenu.tscn")
+
+## Changes scene to scene at given path
+func goto_scene(path:String) -> void:
+	call_deferred("_deferred_go_to_scene", path)
+
+## completes a deffered scene switching
+func _deferred_go_to_scene(path:String) -> void:
+	current_scene.free()
+	var next_scene:Resource = ResourceLoader.load(path)
+	current_scene = next_scene.instantiate()
+	get_tree().root.add_child(current_scene)

--- a/src/project.godot
+++ b/src/project.godot
@@ -14,6 +14,10 @@ config/name="Educational Genetics Game"
 run/main_scene="res://scenes/guis/MainMenu.tscn"
 config/features=PackedStringArray("4.2")
 
+[autoload]
+
+SceneSwitching="*res://features/scene-switching/scene_switching.gd"
+
 [debug]
 
 gdscript/warnings/untyped_declaration=2

--- a/src/scenes/guis/pause_button.gd
+++ b/src/scenes/guis/pause_button.gd
@@ -5,7 +5,7 @@ extends Control
 ## by button press or pause key press
 
 var menu_scene:PackedScene = preload("res://scenes/guis/pause_menu.tscn")
-var pause_screen:Control
+var pause_screen:CanvasLayer
 var paused:bool = false
 
 ## listens for pause key (esc)
@@ -19,8 +19,9 @@ func _process(_delta:float) -> void:
 func show_pause_screen() -> void:
 	pause_screen = menu_scene.instantiate()
 	pause_screen.pause = self
-	add_child(pause_screen)
 	$Button.hide()
+	get_tree().paused = true
+	add_child(pause_screen)
 
 ## Show pause screen on button press
 func _on_button_pressed() -> void:
@@ -29,6 +30,7 @@ func _on_button_pressed() -> void:
 		paused = true
 
 func resume_game() -> void:
+	get_tree().paused = false
 	$Button.show()
 	paused = false
 	pause_screen.queue_free()

--- a/src/scenes/guis/pause_menu.gd
+++ b/src/scenes/guis/pause_menu.gd
@@ -1,10 +1,10 @@
-extends Control
+extends CanvasLayer
 ## pause menu functionality
 
 var pause:Control
 
 func _on_resume_pressed() -> void:
-	get_parent().resume_game()
+	pause.resume_game()
 
 func _on_exit_pressed() -> void:
 	## add logic to reuturn to main menu

--- a/src/scenes/guis/pause_menu.gd
+++ b/src/scenes/guis/pause_menu.gd
@@ -8,7 +8,7 @@ func _on_resume_pressed() -> void:
 
 func _on_exit_pressed() -> void:
 	## add logic to reuturn to main menu
-	pass
+	SceneSwitching.goto_mainmenu()
 
 func _on_settings_pressed() -> void:
 	# add logic to bring up settings screen

--- a/src/scenes/guis/pause_menu.tscn
+++ b/src/scenes/guis/pause_menu.tscn
@@ -1,18 +1,23 @@
-[gd_scene load_steps=2 format=3 uid="uid://wmlthonc6smw"]
+[gd_scene load_steps=3 format=3 uid="uid://wmlthonc6smw"]
 
 [ext_resource type="Script" path="res://scenes/guis/pause_menu.gd" id="1_ytf5f"]
 
-[node name="PauseMenu" type="Control"]
-layout_mode = 3
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_rrqdw"]
+
+[node name="PauseMenu" type="CanvasLayer"]
+process_mode = 2
+layer = 128
+script = ExtResource("1_ytf5f")
+
+[node name="TextureRect" type="TextureRect" parent="."]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-script = ExtResource("1_ytf5f")
+texture = SubResource("PlaceholderTexture2D_rrqdw")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5


### PR DESCRIPTION
Pausing now pauses the processing of all nodes in the tree.

Pause button scene must be instantiated in your scene tree if you want pausing functionality.

Added pause scene to codon minigame to showcase